### PR TITLE
Django 2 support

### DIFF
--- a/django_sorting_field/fields.py
+++ b/django_sorting_field/fields.py
@@ -1,7 +1,7 @@
 import json
 
 from django import forms
-from django.utils.text import force_text
+from django.utils.encoding import force_text
 
 from .utils import clean_order_json, sort_by_order
 from .widgets import SortingWidget

--- a/django_sorting_field/widgets.py
+++ b/django_sorting_field/widgets.py
@@ -15,7 +15,7 @@ class SortingWidget(Widget):
             "sorting/js/sorting_widget.js",
         )
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         context = attrs
         context.update({
             "items": value,


### PR DESCRIPTION
Quick fix to support Django 2. force_text lives in django.utils.encoding, but Django 1.x imports that into django.utils.text.